### PR TITLE
fix: remediate Ivanti ITSM Flashpoint findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: Ivanti ITSM
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================

--- a/README.md
+++ b/README.md
@@ -746,7 +746,6 @@ action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusin
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.IdentityId | string | | 9f269009-2119-e411-84ee-005056a60016 050f8ac7-3450-e711-948c-061b2fd21d7a |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InitialNotReadyReasonValue | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InitialNotReadyReasonValue_Valid | string | | |
-action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InternalAuthPasswd | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InternalPwdDateTime | string | | 2017-06-13 04:25:34 2017-06-21 16:00:00 |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.IsAutoProvisioned | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.IsExternalAuth | boolean | | True False |
@@ -818,7 +817,6 @@ action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusin
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TeamEmail | string | `email` | test@phantom.us |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TeamManagerEmail | string | `email` | test@phantom.us |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.Team_Valid | string | `md5` | 10F60157A4F34A4F9DDB140E2328C7A6 2E4BABD54FB9420D94F836F0D9B80C47 |
-action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TempInternalAuthPassword | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TempPwdDatetime | string | | 2016-09-02 09:46:35 |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TerminatedDate | string | | 2008-09-17 00:00:00 |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.Title | string | | IT Manager |
@@ -951,7 +949,6 @@ action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusin
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.IdentityId | string | | 9f269009-2119-e411-84ee-005056a60016 |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InitialNotReadyReasonValue | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InitialNotReadyReasonValue_Valid | string | | |
-action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InternalAuthPasswd | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.InternalPwdDateTime | string | | 2017-06-13 04:25:34 |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.IsAutoProvisioned | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.IsExternalAuth | boolean | | True False |
@@ -1023,7 +1020,6 @@ action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusin
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TeamEmail | string | `email` | test@phantom.us |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TeamManagerEmail | string | `email` | test@phantom.us |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.Team_Valid | string | `md5` | 10F60157A4F34A4F9DDB140E2328C7A6 |
-action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TempInternalAuthPassword | string | | |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TempPwdDatetime | string | | 2016-09-02 09:46:35 |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.TerminatedDate | string | | 2008-09-17 00:00:00 |
 action_result.data.\*.objList.ArrayOfWebServiceBusinessObject.\*.WebServiceBusinessObject.\*.FieldValues.Title | string | | IT Manager |
@@ -1070,7 +1066,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ivantiitsm.json
+++ b/ivantiitsm.json
@@ -9,7 +9,7 @@
     "product_name": "ITSM",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "app_version": "3.0.9",
     "utctime_updated": "2025-09-18T20:22:23.020492Z",
     "package_name": "phantom_ivanti_itsm",

--- a/ivantiitsm.json
+++ b/ivantiitsm.json
@@ -4272,10 +4272,6 @@
                     "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.InternalAuthPasswd",
-                    "data_type": "string"
-                },
-                {
                     "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.InternalPwdDateTime",
                     "data_type": "string",
                     "example_values": [
@@ -4760,10 +4756,6 @@
                         "10F60157A4F34A4F9DDB140E2328C7A6",
                         "2E4BABD54FB9420D94F836F0D9B80C47"
                     ]
-                },
-                {
-                    "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.TempInternalAuthPassword",
-                    "data_type": "string"
                 },
                 {
                     "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.TempPwdDatetime",
@@ -5519,10 +5511,6 @@
                     "data_type": "string"
                 },
                 {
-                    "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.InternalAuthPasswd",
-                    "data_type": "string"
-                },
-                {
                     "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.InternalPwdDateTime",
                     "data_type": "string",
                     "example_values": [
@@ -5993,10 +5981,6 @@
                     "example_values": [
                         "10F60157A4F34A4F9DDB140E2328C7A6"
                     ]
-                },
-                {
-                    "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.TempInternalAuthPassword",
-                    "data_type": "string"
                 },
                 {
                     "data_path": "action_result.data.*.objList.ArrayOfWebServiceBusinessObject.*.WebServiceBusinessObject.*.FieldValues.TempPwdDatetime",

--- a/ivantiitsm_connector.py
+++ b/ivantiitsm_connector.py
@@ -260,15 +260,15 @@ class HeatConnector(BaseConnector):
         if phantom.is_fail(ret_val):
             return ret_val
 
+        poll_end_time = datetime.utcnow().strftime(consts.HEAT_TIME_FORMAT)
+        update_checkpoint = not self.is_poll_now()
         if self.is_poll_now():
             start_time = (datetime.utcnow() - timedelta(days=int(config["poll_now_ingestion_span"]))).strftime(consts.HEAT_TIME_FORMAT)
         elif self._state.get("first_run", True):
-            self._state["first_run"] = False
             start_time = (datetime.utcnow() - timedelta(days=int(config["first_scheduled_ingestion_span"]))).strftime(consts.HEAT_TIME_FORMAT)
-            self._state["last_time"] = datetime.utcnow().strftime(consts.HEAT_TIME_FORMAT)
         else:
-            start_time = self._state["last_time"]
-            self._state["last_time"] = datetime.utcnow().strftime(consts.HEAT_TIME_FORMAT)
+            checkpoint = datetime.strptime(self._state["last_time"], consts.HEAT_TIME_FORMAT) - timedelta(seconds=1)
+            start_time = checkpoint.strftime(consts.HEAT_TIME_FORMAT)
 
         from_date_obj = self._client.factory.create("RuleClass")
         from_date_obj._Condition = ">"
@@ -305,16 +305,24 @@ class HeatConnector(BaseConnector):
 
         tickets = response.get("objList", {}).get("ArrayOfWebServiceBusinessObject", {})
         if not tickets:
+            if update_checkpoint:
+                self._state["first_run"] = False
+                self._state["last_time"] = poll_end_time
             return action_result.set_status(phantom.APP_SUCCESS, "No tickets to ingest")
 
+        failed_tickets = 0
         for ticket in tickets:
             ticket = ticket.get("WebServiceBusinessObject", [{}])[0]
 
             if not ticket:
+                failed_tickets += 1
                 continue
 
-            ticket_id = ticket["RecID"]
-            ticket = ticket["FieldValues"]
+            ticket_id = ticket.get("RecID")
+            ticket = ticket.get("FieldValues", {})
+            if not ticket_id or not ticket.get("Subject") or not ticket.get("Symptom"):
+                failed_tickets += 1
+                continue
 
             container = {}
             container["name"] = ticket["Subject"]
@@ -324,7 +332,9 @@ class HeatConnector(BaseConnector):
             ret_val, message, container_id = self.save_container(container)
 
             if phantom.is_fail(ret_val):
-                return action_result.set_status(phantom.APP_ERROR, message)
+                failed_tickets += 1
+                self.debug_print(f"Could not save Ivanti ticket {ticket_id}: {message}")
+                continue
 
             artifact = {}
             artifact["label"] = "ticket"
@@ -347,6 +357,16 @@ class HeatConnector(BaseConnector):
             }
 
             self.save_artifact(artifact)
+
+        if failed_tickets:
+            return action_result.set_status(
+                phantom.APP_ERROR,
+                f"Failed to ingest {failed_tickets} Ivanti ticket(s); the polling checkpoint was not advanced",
+            )
+
+        if update_checkpoint:
+            self._state["first_run"] = False
+            self._state["last_time"] = poll_end_time
         self.debug_print("on poll action succeeded.")
         return action_result.set_status(phantom.APP_SUCCESS)
 

--- a/ivantiitsm_connector.py
+++ b/ivantiitsm_connector.py
@@ -25,9 +25,51 @@ import phantom.rules as ph_rules
 from phantom.action_result import ActionResult
 from phantom.base_connector import BaseConnector
 from suds.client import Client
+from suds.plugin import DocumentPlugin, MessagePlugin
 from suds.sudsobject import asdict
+from suds.transport.http import HttpAuthenticated
 
 import ivantiitsm_consts as consts
+
+MAX_XML_RESPONSE_BYTES = 16 * 1024 * 1024
+UNSAFE_XML_MARKERS = (b"<!DOCTYPE", b"<!ENTITY")
+
+
+class _LimitedResponse:
+    def __init__(self, response):
+        self._response = response
+
+    def __getattr__(self, name):
+        return getattr(self._response, name)
+
+    def read(self, size=None):
+        read_size = MAX_XML_RESPONSE_BYTES + 1 if size is None else min(size, MAX_XML_RESPONSE_BYTES + 1)
+        content = self._response.read(read_size)
+        if len(content) > MAX_XML_RESPONSE_BYTES:
+            raise ValueError("Ivanti ITSM XML response exceeds the 16 MiB safety limit")
+        return content
+
+
+class _LimitedHttpTransport(HttpAuthenticated):
+    def u2open(self, request):
+        return _LimitedResponse(super().u2open(request))
+
+
+class _RejectUnsafeXmlPlugin(DocumentPlugin, MessagePlugin):
+    @staticmethod
+    def _validate(payload):
+        content = payload.encode("utf-8") if isinstance(payload, str) else bytes(payload)
+        if len(content) > MAX_XML_RESPONSE_BYTES:
+            raise ValueError("Ivanti ITSM XML response exceeds the 16 MiB safety limit")
+        upper_content = content.upper()
+        if any(marker in upper_content for marker in UNSAFE_XML_MARKERS):
+            raise ValueError("Ivanti ITSM XML response contains a prohibited DTD or entity declaration")
+
+    def loaded(self, context):
+        self._validate(context.document)
+
+    def received(self, context):
+        self._validate(context.reply)
 
 
 class RetVal(tuple):
@@ -78,10 +120,16 @@ class HeatConnector(BaseConnector):
 
     def _connect(self, action_result):
         try:
+            client_options = {
+                "plugins": [_RejectUnsafeXmlPlugin()],
+                "transport": _LimitedHttpTransport(),
+            }
             if self._proxy:
-                self._client = Client(url="{}{}".format(self._base_url, "ServiceAPI/FRSHEATIntegration.asmx?wsdl"), proxy=self._proxy)
-            else:
-                self._client = Client(url="{}{}".format(self._base_url, "ServiceAPI/FRSHEATIntegration.asmx?wsdl"))
+                client_options["proxy"] = self._proxy
+            self._client = Client(
+                url="{}{}".format(self._base_url, "ServiceAPI/FRSHEATIntegration.asmx?wsdl"),
+                **client_options,
+            )
 
             ret_val, response = self._make_soap_call(action_result, "Connect", (self._username, self._password, self._tenant, "Admin"))
             if not ret_val:

--- a/ivantiitsm_connector.py
+++ b/ivantiitsm_connector.py
@@ -33,6 +33,7 @@ import ivantiitsm_consts as consts
 
 MAX_XML_RESPONSE_BYTES = 16 * 1024 * 1024
 UNSAFE_XML_MARKERS = (b"<!DOCTYPE", b"<!ENTITY")
+SENSITIVE_RESPONSE_FIELDS = frozenset({"internalauthpasswd", "tempinternalauthpassword"})
 
 
 class _LimitedResponse:
@@ -153,7 +154,18 @@ class HeatConnector(BaseConnector):
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, "SOAP call to ITSM failed", e), None)
 
-        return True, self._suds_to_dict(response)
+        return True, self._strip_sensitive_fields(self._suds_to_dict(response))
+
+    def _strip_sensitive_fields(self, value):
+        if isinstance(value, dict):
+            return {
+                key: self._strip_sensitive_fields(child)
+                for key, child in value.items()
+                if key.casefold() not in SENSITIVE_RESPONSE_FIELDS
+            }
+        if isinstance(value, list):
+            return [self._strip_sensitive_fields(child) for child in value]
+        return value
 
     def _suds_to_dict(self, sud_obj):
         if hasattr(sud_obj, "__keylist__"):

--- a/ivantiitsm_connector.py
+++ b/ivantiitsm_connector.py
@@ -1,6 +1,6 @@
 # File: ivantiitsm_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ from suds.sudsobject import asdict
 from suds.transport.http import HttpAuthenticated
 
 import ivantiitsm_consts as consts
+
 
 MAX_XML_RESPONSE_BYTES = 16 * 1024 * 1024
 UNSAFE_XML_MARKERS = (b"<!DOCTYPE", b"<!ENTITY")
@@ -158,11 +159,7 @@ class HeatConnector(BaseConnector):
 
     def _strip_sensitive_fields(self, value):
         if isinstance(value, dict):
-            return {
-                key: self._strip_sensitive_fields(child)
-                for key, child in value.items()
-                if key.casefold() not in SENSITIVE_RESPONSE_FIELDS
-            }
+            return {key: self._strip_sensitive_fields(child) for key, child in value.items() if key.casefold() not in SENSITIVE_RESPONSE_FIELDS}
         if isinstance(value, list):
             return [self._strip_sensitive_fields(child) for child in value]
         return value

--- a/ivantiitsm_consts.py
+++ b/ivantiitsm_consts.py
@@ -1,6 +1,6 @@
 # File: ivantiitsm_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Reject unsafe or oversized Ivanti SOAP and WSDL XML before parsing
+* Advance polling checkpoints only after the full ticket window is persisted

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Reject unsafe or oversized Ivanti SOAP and WSDL XML before parsing
 * Advance polling checkpoints only after the full ticket window is persisted
+* Strip employee password fields from all persisted SOAP responses

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Reject unsafe or oversized Ivanti SOAP and WSDL XML before parsing


### PR DESCRIPTION
## Summary\n\n- reject unsafe or oversized WSDL and SOAP XML before suds parsing\n- advance scheduled polling checkpoints only after a full ticket window persists\n- strip internal and temporary employee passwords from all SOAP results\n- update connector development tooling and generated artifacts\n\n## Tracking\n\n- Parent: PAPP-38217\n- Findings: PSAAS-31938, PSAAS-32277, PSAAS-32425\n- Epic: ESPM-5228\n\nThe two disclosure-only read-only findings mapped to this repo are excluded from this PR and will be handled under the campaign invalidation policy.\n\n## Quality gate\n\n- Local pre-commit: passed\n- Hosted pre-commit and compile: pending\n\nCreated entirely with AI assistance.\n\nWritten by Codex.

## Tracking

- PAPP: PAPP-38217
- PSAAS: PSAAS-31938, PSAAS-32277, PSAAS-32425
- Written by Codex.